### PR TITLE
docs(readme): reorganize profile presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,160 +1,69 @@
 <div align="center">
   <h1>Hi, I'm João Pedro Araujo</h1>
-  <p>João Pedro Araujo is a Software Engineer with 6+ years of experience across backend engineering, cloud infrastructure, developer tooling, and application security, with a strong foundation in network security vulnerability assessment.</p>
+  <p><strong>Software Engineer</strong> with 5+ years of experience building backend services, cloud-ready systems, developer tooling, and secure engineering workflows.</p>
   <p>
-    <img src="https://img.shields.io/badge/Experience-6%2B%20Years-0f172a?style=for-the-badge" alt="Experience badge" />
+    <img src="https://img.shields.io/badge/Software%20Engineer-5%2B%20Years-0f172a?style=for-the-badge" alt="Software Engineer badge" />
     <img src="https://img.shields.io/badge/Focus-Backend%20%7C%20Cloud%20%7C%20Security-1d4ed8?style=for-the-badge" alt="Focus badge" />
     <img src="https://img.shields.io/badge/Open%20To-Engineering%20Challenges-059669?style=for-the-badge" alt="Open to badge" />
   </p>
 </div>
 
-<div align="center">
-  <img src="https://img.shields.io/badge/Backend-Java%20%7C%20Go%20%7C%20PHP-111827?style=flat-square" alt="Backend badge" />
-  <img src="https://img.shields.io/badge/Cloud-AWS%20%7C%20Azure%20%7C%20Kubernetes-1d4ed8?style=flat-square" alt="Cloud badge" />
-  <img src="https://img.shields.io/badge/Security-Semgrep%20%7C%20Gitleaks%20%7C%20SonarQube-047857?style=flat-square" alt="Security badge" />
-  <img src="https://img.shields.io/badge/Databases-MySQL%20%7C%20PostgreSQL%20%7C%20SQLite-7c3aed?style=flat-square" alt="Databases badge" />
-</div>
-
----
-
-## About Me
-
-I am a Software Engineer with 6+ years of experience building and maintaining systems across backend platforms, cloud environments, containers, and secure development workflows.
-
-My background is centered on designing APIs, maintaining production services, working with relational databases, automating delivery pipelines, and improving code quality with security-first practices.
-
 ---
 
 ## Professional Snapshot
 
-| Area | Summary |
+I work across backend platforms, cloud and container environments, relational data systems, automation, and security-minded delivery practices. My focus is to keep software reliable, maintainable, and practical for production teams.
+
+| Strength | How I apply it |
 | --- | --- |
-| Backend Engineering | Experience with Java, Go, PHP, JavaScript/TypeScript, Python, and Ruby for APIs, services, integrations, and automation |
-| Data & Persistence | Strong familiarity with MySQL, PostgreSQL, SQLite, and Aurora RDS for transactional and operational workloads |
-| Infrastructure | Hands-on work with AWS, Azure, Docker, Kubernetes, and Linux-based environments |
-| Security | Usage of Horusec, Gitleaks, Semgrep, Govulcheck, and SonarQube in review and validation workflows |
-| Collaboration | Daily work with GitHub, GitLab, Jira, Confluence, Trello, Monday, and Zoho |
-| Developer Experience | Comfortable with JetBrains IDEs, shell scripting, CI-oriented tooling, and AI-assisted coding workflows |
+| Backend & APIs | Build and maintain services, integrations, CLIs, and application support workflows across Java, Go, PHP, JavaScript/TypeScript, Python, and Ruby ecosystems. |
+| Cloud & Infrastructure | Work with AWS, Azure, Docker, Kubernetes, Linux environments, Apache Tomcat, and Apache Kafka for deployment, runtime, and operational scenarios. |
+| Data & Persistence | Support transactional and operational workloads with MySQL, PostgreSQL, SQLite, and Aurora RDS for MySQL. |
+| Secure Engineering | Use tools such as Horusec, Gitleaks, Semgrep, Govulcheck, and SonarQube to improve code quality, vulnerability visibility, and review workflows. |
+| Developer Experience | Collaborate with GitHub, GitLab, JetBrains IDEs, Jira, Trello, Monday, Zoho, Confluence, shell workflows, and AI-assisted tools including Cursor, Claude, and GPT/Codex. |
 
----
-
-## Core Stack
-
-### Programming Languages
-
-| Language | Experience |
-| --- | --- |
-| Java | Backend services, enterprise applications, and Spring-based development |
-| Go | Services, CLIs, integrations, and performance-oriented backend workflows |
-| PHP | Web applications, APIs, and Composer-based ecosystems |
-| JavaScript / TypeScript | APIs, tooling, frontends, and Node.js-based workflows |
-| Python | Automation, scripting, integrations, and utility services |
-| Ruby | Maintenance, scripting, and application support in Ruby ecosystems |
-
-### Databases & Persistence
-
-| Technology | Usage |
-| --- | --- |
-| MySQL | Application data, relational modeling, and production support |
-| PostgreSQL | Transactional systems, structured queries, and service persistence |
-| SQLite | Local development, lightweight storage, and test scenarios |
-| Aurora RDS (MySQL) | Managed database operations in AWS environments |
-
-### Cloud, Containers & Infrastructure
-
-| Technology | Usage |
-| --- | --- |
-| AWS | Cloud services, deployments, and managed infrastructure |
-| Azure | Cloud platform operations and service integration |
-| Kubernetes | Container orchestration, workloads, and runtime operations |
-| Docker | Local development, packaging, and container-based delivery |
-| Apache Tomcat | Java application hosting and operational support |
-| Apache Kafka | Event-driven architectures and messaging pipelines |
-
-### Operating Systems
-
-| System | Usage |
-| --- | --- |
-| Debian | Servers, development environments, and tooling |
-| Ubuntu | Local development and deployment workflows |
-| Kali Linux | Security-focused scenarios and tooling usage |
-
----
-
-## Frameworks & Tooling
-
-### Frameworks, Runtimes & Build Tools
+## Technical Stack & Tools
 
 | Category | Technologies |
 | --- | --- |
-| Frameworks | Spring Framework |
-| Runtimes | Node.js |
-| Package & Build | Composer, Yarn, Gradle Wrapper |
-| Shell & CLI | Shell scripting, terminal-first workflows |
+| Programming languages | Java, Go, PHP, JavaScript, TypeScript, Python, Ruby |
+| Frameworks, runtimes & build | Spring Framework, Node.js, Composer, Yarn, Gradle Wrapper, Shell scripting, Apache Tomcat, Apache Kafka |
+| Data & persistence | MySQL, PostgreSQL, SQLite, Aurora RDS (MySQL) |
+| Cloud, containers & systems | AWS, Azure, Kubernetes, Docker, Debian, Ubuntu, Kali Linux |
+| Engineering platforms | GitHub, GitLab, IntelliJ IDEA, GoLand, PhpStorm, DataGrip, Jira, Trello, Monday, Zoho, Confluence |
+| Observability & monitoring | Grafana, Prometheus |
+| Security & quality | Horusec, Gitleaks, Semgrep, Govulcheck, SonarQube |
+| AI-assisted development | Cursor, Claude, GPT / Codex |
 
-### Engineering Platforms
+<details>
+  <summary><strong>Toolbox badges</strong></summary>
 
-| Category | Technologies |
-| --- | --- |
-| Version Control | GitHub, GitLab |
-| IDEs | IntelliJ IDEA, GoLand, PhpStorm, DataGrip, JetBrains ecosystem |
-| Work Tracking | Jira, Trello, Monday, Zoho |
-| Documentation | Confluence |
+  <br />
 
-### Observability & Monitoring
-
-| Tool | Usage |
-| --- | --- |
-| Grafana | Dashboards and operational visibility |
-| Prometheus | Metrics collection and monitoring pipelines |
-
-### AI-Assisted Development
-
-| Tool | Usage |
-| --- | --- |
-| Cursor | AI-assisted implementation and navigation |
-| Claude | Code generation and analysis workflows |
-| GPT / Codex | Engineering support, refactoring, and delivery acceleration |
-
-### Security Tooling
-
-| Tool | Usage |
-| --- | --- |
-| Horusec | Static security analysis |
-| Gitleaks | Secret scanning |
-| Semgrep | Code pattern analysis and secure coding checks |
-| Govulcheck | Go vulnerability inspection |
-| SonarQube | Code quality and security gates |
-
----
-
-## Toolbox
-
-<div align="center">
-  <img src="https://img.shields.io/badge/Java-ED8B00?style=flat-square&logo=openjdk&logoColor=white" alt="Java badge" />
-  <img src="https://img.shields.io/badge/Go-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go badge" />
-  <img src="https://img.shields.io/badge/PHP-777BB4?style=flat-square&logo=php&logoColor=white" alt="PHP badge" />
-  <img src="https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript badge" />
-  <img src="https://img.shields.io/badge/JavaScript-F7DF1E?style=flat-square&logo=javascript&logoColor=black" alt="JavaScript badge" />
-  <img src="https://img.shields.io/badge/Python-3776AB?style=flat-square&logo=python&logoColor=white" alt="Python badge" />
-  <img src="https://img.shields.io/badge/Ruby-CC342D?style=flat-square&logo=ruby&logoColor=white" alt="Ruby badge" />
-  <img src="https://img.shields.io/badge/MySQL-4479A1?style=flat-square&logo=mysql&logoColor=white" alt="MySQL badge" />
-  <img src="https://img.shields.io/badge/PostgreSQL-4169E1?style=flat-square&logo=postgresql&logoColor=white" alt="PostgreSQL badge" />
-  <img src="https://img.shields.io/badge/SQLite-003B57?style=flat-square&logo=sqlite&logoColor=white" alt="SQLite badge" />
-  <img src="https://img.shields.io/badge/AWS-232F3E?style=flat-square&logo=amazonaws&logoColor=white" alt="AWS badge" />
-  <img src="https://img.shields.io/badge/Azure-0078D4?style=flat-square&logo=microsoftazure&logoColor=white" alt="Azure badge" />
-  <img src="https://img.shields.io/badge/Kubernetes-326CE5?style=flat-square&logo=kubernetes&logoColor=white" alt="Kubernetes badge" />
-  <img src="https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white" alt="Docker badge" />
-  <img src="https://img.shields.io/badge/Spring-6DB33F?style=flat-square&logo=spring&logoColor=white" alt="Spring badge" />
-  <img src="https://img.shields.io/badge/Kafka-231F20?style=flat-square&logo=apachekafka&logoColor=white" alt="Kafka badge" />
-  <img src="https://img.shields.io/badge/Grafana-F46800?style=flat-square&logo=grafana&logoColor=white" alt="Grafana badge" />
-  <img src="https://img.shields.io/badge/Prometheus-E6522C?style=flat-square&logo=prometheus&logoColor=white" alt="Prometheus badge" />
-  <img src="https://img.shields.io/badge/GitHub-181717?style=flat-square&logo=github&logoColor=white" alt="GitHub badge" />
-  <img src="https://img.shields.io/badge/GitLab-FC6D26?style=flat-square&logo=gitlab&logoColor=white" alt="GitLab badge" />
-  <img src="https://img.shields.io/badge/SonarQube-4E9BCD?style=flat-square&logo=sonarqube&logoColor=white" alt="SonarQube badge" />
-</div>
-
----
+  <div align="center">
+    <img src="https://img.shields.io/badge/Java-ED8B00?style=flat-square&logo=openjdk&logoColor=white" alt="Java badge" />
+    <img src="https://img.shields.io/badge/Go-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go badge" />
+    <img src="https://img.shields.io/badge/PHP-777BB4?style=flat-square&logo=php&logoColor=white" alt="PHP badge" />
+    <img src="https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript badge" />
+    <img src="https://img.shields.io/badge/JavaScript-F7DF1E?style=flat-square&logo=javascript&logoColor=black" alt="JavaScript badge" />
+    <img src="https://img.shields.io/badge/Python-3776AB?style=flat-square&logo=python&logoColor=white" alt="Python badge" />
+    <img src="https://img.shields.io/badge/Ruby-CC342D?style=flat-square&logo=ruby&logoColor=white" alt="Ruby badge" />
+    <img src="https://img.shields.io/badge/MySQL-4479A1?style=flat-square&logo=mysql&logoColor=white" alt="MySQL badge" />
+    <img src="https://img.shields.io/badge/PostgreSQL-4169E1?style=flat-square&logo=postgresql&logoColor=white" alt="PostgreSQL badge" />
+    <img src="https://img.shields.io/badge/SQLite-003B57?style=flat-square&logo=sqlite&logoColor=white" alt="SQLite badge" />
+    <img src="https://img.shields.io/badge/AWS-232F3E?style=flat-square&logo=amazonaws&logoColor=white" alt="AWS badge" />
+    <img src="https://img.shields.io/badge/Azure-0078D4?style=flat-square&logo=microsoftazure&logoColor=white" alt="Azure badge" />
+    <img src="https://img.shields.io/badge/Kubernetes-326CE5?style=flat-square&logo=kubernetes&logoColor=white" alt="Kubernetes badge" />
+    <img src="https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white" alt="Docker badge" />
+    <img src="https://img.shields.io/badge/Spring-6DB33F?style=flat-square&logo=spring&logoColor=white" alt="Spring badge" />
+    <img src="https://img.shields.io/badge/Kafka-231F20?style=flat-square&logo=apachekafka&logoColor=white" alt="Kafka badge" />
+    <img src="https://img.shields.io/badge/Grafana-F46800?style=flat-square&logo=grafana&logoColor=white" alt="Grafana badge" />
+    <img src="https://img.shields.io/badge/Prometheus-E6522C?style=flat-square&logo=prometheus&logoColor=white" alt="Prometheus badge" />
+    <img src="https://img.shields.io/badge/GitHub-181717?style=flat-square&logo=github&logoColor=white" alt="GitHub badge" />
+    <img src="https://img.shields.io/badge/GitLab-FC6D26?style=flat-square&logo=gitlab&logoColor=white" alt="GitLab badge" />
+    <img src="https://img.shields.io/badge/SonarQube-4E9BCD?style=flat-square&logo=sonarqube&logoColor=white" alt="SonarQube badge" />
+  </div>
+</details>
 
 ## Connect With Me
 
@@ -174,8 +83,6 @@ My background is centered on designing APIs, maintaining production services, wo
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/sant0x00/sant0x00/output/github-snake.svg" alt="snake animation" />
-</div>
-
-<div align="center">
+  <br />
   <img src="https://komarev.com/ghpvc/?username=sant0x00&style=for-the-badge&color=0f766e" alt="Profile views" />
 </div>


### PR DESCRIPTION
This pull request updates and streamlines the `README.md` to present a more concise, focused, and modern overview of the author's skills, experience, and technical stack. The changes improve readability, highlight key strengths, and reorganize content for clarity and easier navigation.

**Summary of most important changes:**

**Profile and Experience Overview:**
* Updated the introductory paragraph to a more concise summary, emphasizing 5+ years of experience and focusing on backend, cloud, and security engineering.
* Replaced the experience badge with a new one reflecting "Software Engineer - 5+ Years" for a more accurate and current representation.

**Content Reorganization and Simplification:**
* Removed detailed sections about background, core stack, and lengthy tables, replacing them with a summarized "Strength" table and a condensed technical stack section.
* Collapsed the toolbox badges into a `<details>` section for a cleaner layout and easier navigation.

**Formatting and Presentation:**
* Improved the presentation of badges and profile views, and cleaned up extra dividers and whitespace for a more modern and visually appealing README.